### PR TITLE
chocolatey-misc-helpers: Made output pipable

### DIFF
--- a/chocolatey-misc-helpers.extension/extensions/Start-CheckandStop.ps1
+++ b/chocolatey-misc-helpers.extension/extensions/Start-CheckandStop.ps1
@@ -9,7 +9,7 @@ function Start-CheckandStop($ProcessName){
 $GLOBAL:ProcessWasRunning=$False
 
 if((Get-Process "$ProcessName" -ea SilentlyContinue) -eq $Null){ 
-    Write-Host "  ** $ProcessName currently NOT running." -ForeGround Green
+    Write-Output "  ** $ProcessName currently NOT running."
   }else{ 
     Write-Warning "  ** Stopping $ProcessName process..."
 	$GLOBAL:ProcessWasRunning = $True

--- a/chocolatey-misc-helpers.extension/extensions/Test-Dependency.ps1
+++ b/chocolatey-misc-helpers.extension/extensions/Test-Dependency.ps1
@@ -7,12 +7,12 @@
 # installed and abort if not. Example: Test-Dependency "dependency-windows10"
 # You would typically run this sometime before Install-ChocolateyPackage
 
-function Test-Dependency($dependency){
-if (Test-Path -Path $env:ChocolateyInstall\lib\$dependency){
+function Test-Dependency($Dependency){
+if (Test-Path -Path $env:ChocolateyInstall\lib\$Dependency){
     return $True
-	Write-Host "  ** Dependency $dependency found." -ForeGround Green
+	Write-Output "  ** Dependency $Dependency found."
     } else {
 	  return $False
-	  Write-Host "  ** Dependency $dependency NOT found." -ForeGround Red
+	  Write-Output "  ** Dependency $Dependency NOT found."
     }
 }


### PR DESCRIPTION
Because these functions used `Write-Host`, their outputs couldn't be suppressed with `> $null` or `| Out-Null`. This was confusing and annoying. Even though, on PS >= 5.0, you can suppress their outputs with `6> $null`. However, if you do that, you have to work around the fact that it will cause issues on older PowerShell versions.

We lose the green, because you can only do that with `Write-Host`, but, personally, I did not like the green text anyway, and that was perhaps a reason why I wanted to suppress the output. I am also not a big fan of the asterisks.
On PS >= 7 I think, there is a way to get color with `Write-Output`. So maybe you could do a check for PS version and display color if it's using a newer version of PS, or something like that. I personally only have Windows PowerShell 5.1, that ships with W11.
